### PR TITLE
fix: create at id

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+What is the background of this pull request?
+
+## Changes
+
+- What are the changes made in this pull request?
+- Change this and that, etc...
+
+## Issues
+
+What are the related issues or stories?

--- a/netlify/functions/storage/createAtId.ts
+++ b/netlify/functions/storage/createAtId.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from "uuid";
 import { validateUpload, getEncryptedDocument } from "../../utils";
 import { getDocument } from "./get";
 import { s3Put } from "../../services/s3";
@@ -13,15 +12,14 @@ const uploadDocumentAtId = async (document, documentId: string) => {
       existingKey,
     });
 
-  const id = uuid();
   await s3Put({
     Bucket: process.env.TT_AWS_BUCKET_NAME,
-    Key: id,
+    Key: documentId,
     Body: JSON.stringify({ document: encryptedDocument }),
   });
 
   return {
-    id,
+    id: documentId,
     key: encryptedDocumentKey,
     type: encryptedDocument.type,
   };

--- a/tests/integration/document-storage.test.ts
+++ b/tests/integration/document-storage.test.ts
@@ -61,7 +61,7 @@ describe("GET /:id", () => {
 });
 
 describe("POST /:id", () => {
-  it("store a new encrypted document, using retrieved key from specified id of previous queue", async () => {
+  it("store a new encrypted document, replacing specified id from previous queue while using the retrieved decrypt key", async () => {
     const queueResponse = await request.get("/queue").expect(200);
 
     const response = await request
@@ -69,8 +69,8 @@ describe("POST /:id", () => {
       .send(postData)
       .expect(200);
 
-    expect(response.body).toHaveProperty("id");
-    expect(response.body).toHaveProperty("key", queueResponse.body.key);
+    expect(response.body).toHaveProperty("id", queueResponse.body.id); // important to check!
+    expect(response.body).toHaveProperty("key", queueResponse.body.key); // important to check!
     expect(response.body).toHaveProperty("type", "OPEN-ATTESTATION-TYPE-1");
     expect(Object.keys(response.body).length).toBe(3);
   });


### PR DESCRIPTION
## Summary

- `createAtId` was creating a new s3 object. this is unintended.

## Changes

- use back same id from `queue`