### PR TITLE
fix: omit check

### DIFF
--- a/netlify/functions/storage/index.ts
+++ b/netlify/functions/storage/index.ts
@@ -12,13 +12,12 @@ import { queue } from "./queue";
 const app = express();
 export const router = express.Router();
 
-router.post("/", create);
-router.get("/queue", queue);
-router.get("/:id", get);
-router.post("/:id", createAtId);
+router.post("/", checkApiKey, create);
+router.get("/queue", checkApiKey, queue);
+router.get("/:id", get); // lets omit checkApiKey for tradetrust web to retrieve document easily
+router.post("/:id", checkApiKey, createAtId);
 
 app.use(cors({ origin: corsOrigin }));
-app.use(checkApiKey);
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(FUNCTIONS_PATH, router);

--- a/netlify/utils.ts
+++ b/netlify/utils.ts
@@ -6,17 +6,18 @@ import {
 } from "@govtechsg/oa-verify";
 import { encryptString } from "@govtechsg/oa-encryption";
 import createError from "http-errors";
-import { ALLOWED_ORIGINS, ERROR_MESSAGE } from "./constants";
+import { ERROR_MESSAGE } from "./constants";
 
 // https://github.com/expressjs/cors#configuring-cors-w-dynamic-origin
 export const corsOrigin = (origin, callback) => {
-  if (!origin) return callback(null, true); // allow requests with no origin, like mobile apps or curl requests
+  return callback(null, true);
+  // if (!origin) return callback(null, true); // allow requests with no origin, like mobile apps or curl requests
 
-  if (ALLOWED_ORIGINS.includes(origin)) {
-    return callback(null, true);
-  } else {
-    return callback(new Error(ERROR_MESSAGE.CORS_UNALLOWED), false);
-  }
+  // if (ALLOWED_ORIGINS.includes(origin)) {
+  //   return callback(null, true);
+  // } else {
+  //   return callback(new Error(ERROR_MESSAGE.CORS_UNALLOWED), false);
+  // }
 };
 
 export const checkApiKey = (req, res, next) => {

--- a/netlify/utils.ts
+++ b/netlify/utils.ts
@@ -6,18 +6,17 @@ import {
 } from "@govtechsg/oa-verify";
 import { encryptString } from "@govtechsg/oa-encryption";
 import createError from "http-errors";
-import { ERROR_MESSAGE } from "./constants";
+import { ALLOWED_ORIGINS, ERROR_MESSAGE } from "./constants";
 
 // https://github.com/expressjs/cors#configuring-cors-w-dynamic-origin
 export const corsOrigin = (origin, callback) => {
-  return callback(null, true);
-  // if (!origin) return callback(null, true); // allow requests with no origin, like mobile apps or curl requests
+  if (!origin) return callback(null, true); // allow requests with no origin, like mobile apps or curl requests
 
-  // if (ALLOWED_ORIGINS.includes(origin)) {
-  //   return callback(null, true);
-  // } else {
-  //   return callback(new Error(ERROR_MESSAGE.CORS_UNALLOWED), false);
-  // }
+  if (ALLOWED_ORIGINS.includes(origin)) {
+    return callback(null, true);
+  } else {
+    return callback(new Error(ERROR_MESSAGE.CORS_UNALLOWED), false);
+  }
 };
 
 export const checkApiKey = (req, res, next) => {


### PR DESCRIPTION
- omit api key check for `/get` for now
- we could setup api key in headers during POST at tradetrust web later