### PR TITLE
refactor: chain id

### DIFF
--- a/netlify/constants.ts
+++ b/netlify/constants.ts
@@ -32,45 +32,60 @@ const jsonRpcProvider =
   () =>
     new providers.JsonRpcProvider(url);
 
-export enum NETWORK {
-  MAINNET = "mainnet",
-  MATIC = "matic",
-  MATICMUM = "maticmum",
-  GOERLI = "goerli",
-  SEPOLIA = "sepolia",
+export enum CHAIN_ID {
+  MAINNET = 1,
+  MATIC = 137,
+  MATICMUM = 80001,
+  GOERLI = 5,
+  SEPOLIA = 11155111,
 }
 
+export const supportedNetworks = [
+  "mainnet",
+  "matic",
+  "maticmum",
+  "goerli",
+  "sepolia",
+] as const;
+export type network = typeof supportedNetworks[number];
+
 type SupportedNetworks = {
-  [index in NETWORK]: {
+  [index in CHAIN_ID]: {
     label: string;
+    network: network;
     type: "production" | "test";
     provider: () => providers.Provider;
   };
 };
 
 export const SUPPORTED_NETWORKS: SupportedNetworks = {
-  [NETWORK.MAINNET]: {
+  [CHAIN_ID.MAINNET]: {
     label: "Mainnet",
+    network: "mainnet",
     type: "production",
     provider: infuraProvider("homestead"),
   },
-  [NETWORK.MATIC]: {
+  [CHAIN_ID.MATIC]: {
     label: "Polygon",
+    network: "matic",
     type: "production",
     provider: infuraProvider("matic"),
   },
-  [NETWORK.MATICMUM]: {
+  [CHAIN_ID.MATICMUM]: {
     label: "Polygon Mumbai",
+    network: "maticmum",
     type: "test",
     provider: infuraProvider("maticmum"),
   },
-  [NETWORK.GOERLI]: {
+  [CHAIN_ID.GOERLI]: {
     label: "Goerli",
+    network: "goerli",
     type: "test",
     provider: infuraProvider("goerli"),
   },
-  [NETWORK.SEPOLIA]: {
+  [CHAIN_ID.SEPOLIA]: {
     label: "Sepolia",
+    network: "sepolia",
     type: "test",
     provider: jsonRpcProvider("https://rpc.sepolia.org"),
   },

--- a/netlify/functions/storage/create.ts
+++ b/netlify/functions/storage/create.ts
@@ -1,10 +1,13 @@
 import { v4 as uuid } from "uuid";
 import { validateDocument, getEncryptedDocument } from "../../utils";
 import { s3Put } from "../../services/s3";
-import { NETWORK } from "../../constants";
+import { SUPPORTED_NETWORKS, CHAIN_ID } from "../../constants";
 
 const uploadDocument = async (document) => {
-  await validateDocument({ document, network: NETWORK.GOERLI });
+  await validateDocument({
+    document,
+    network: SUPPORTED_NETWORKS[CHAIN_ID.GOERLI].network,
+  });
 
   const { encryptedDocument, encryptedDocumentKey } =
     await getEncryptedDocument({

--- a/netlify/functions/storage/createAtId.ts
+++ b/netlify/functions/storage/createAtId.ts
@@ -1,10 +1,13 @@
 import { validateDocument, getEncryptedDocument } from "../../utils";
 import { getDocument } from "./get";
 import { s3Put } from "../../services/s3";
-import { NETWORK } from "../../constants";
+import { SUPPORTED_NETWORKS, CHAIN_ID } from "../../constants";
 
 const uploadDocumentAtId = async (document, documentId: string) => {
-  await validateDocument({ document, network: NETWORK.GOERLI });
+  await validateDocument({
+    document,
+    network: SUPPORTED_NETWORKS[CHAIN_ID.GOERLI].network,
+  });
 
   const { key: existingKey } = await getDocument(documentId);
   const { encryptedDocument, encryptedDocumentKey } =

--- a/netlify/functions/verify/verifyDocument.ts
+++ b/netlify/functions/verify/verifyDocument.ts
@@ -1,20 +1,5 @@
 import { isValid } from "@govtechsg/oa-verify";
-import createError from "http-errors";
 import { validateDocument } from "../../utils";
-import { ERROR_MESSAGE, NETWORK } from "../../constants";
-
-const supportedNetworks = Object.values(NETWORK);
-
-const getFragments = async ({ document, network }) => {
-  if (!supportedNetworks.includes(network)) {
-    throw new createError(400, ERROR_MESSAGE.NETWORK_UNSUPPORTED);
-  }
-
-  return await validateDocument({
-    document,
-    network,
-  });
-};
 
 export const verifyDocument = async (req, res) => {
   const {
@@ -23,7 +8,7 @@ export const verifyDocument = async (req, res) => {
   } = req;
 
   try {
-    const fragments = await getFragments({
+    const fragments = await validateDocument({
       document,
       network,
     });

--- a/netlify/utils.ts
+++ b/netlify/utils.ts
@@ -10,7 +10,8 @@ import {
   ALLOWED_ORIGINS,
   ERROR_MESSAGE,
   SUPPORTED_NETWORKS,
-  NETWORK,
+  supportedNetworks,
+  network,
 } from "./constants";
 
 // https://github.com/expressjs/cors#configuring-cors-w-dynamic-origin
@@ -32,18 +33,28 @@ export const checkApiKey = (req, res, next) => {
   next();
 };
 
+const getSupportedProvider = (network: network) => {
+  return Object.values(SUPPORTED_NETWORKS)
+    .find((item) => item.network === network)
+    .provider();
+};
+
 export const validateDocument = async ({
   document,
   network,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   document: any;
-  network: NETWORK;
+  network: network;
 }) => {
+  if (!supportedNetworks.includes(network)) {
+    throw new createError(400, ERROR_MESSAGE.NETWORK_UNSUPPORTED);
+  }
+
   const verify = verificationBuilder(
     [...openAttestationVerifiers, openAttestationDidIdentityProof],
     {
-      provider: SUPPORTED_NETWORKS[network].provider(),
+      provider: getSupportedProvider(network),
     },
   );
 


### PR DESCRIPTION
## Summary

- moving forward, will rely on `chainId`
- this pr is in preparation for document storage service to allow validation of OA document against their own network, with required `network` field

## Changes

- refactor from `network` key to `chainId` key
- throw error as soon as network not supported in validateDocument
